### PR TITLE
Fix/missing labels in config

### DIFF
--- a/nlptest/transform/accuracy.py
+++ b/nlptest/transform/accuracy.py
@@ -83,6 +83,8 @@ class MinPrecisionScore(BaseAccuracy):
 
         precision_samples = []
         for k, v in df_metrics.items():
+            if k not in min_scores.keys():
+                continue
             sample = Sample(
                 original = "-",
                 category = "Accuracy",
@@ -138,6 +140,8 @@ class MinRecallScore(BaseAccuracy):
 
         rec_samples = []
         for k, v in df_metrics.items():
+            if k not in min_scores.keys():
+                continue
             sample = Sample(
                 original = "-",
                 category = "Accuracy",
@@ -194,6 +198,8 @@ class MinF1Score(BaseAccuracy):
 
         f1_samples = []
         for k, v in df_metrics.items():
+            if k not in min_scores.keys():
+                continue
             sample = Sample(
                 original = "-",
                 category = "Accuracy",

--- a/nlptest/transform/fairness.py
+++ b/nlptest/transform/fairness.py
@@ -78,6 +78,8 @@ class MinGenderF1Score(BaseFairness):
         samples = []
 
         for key, val in gendered_data.items():
+            if key not in min_scores.keys():
+                continue
             y_true = pd.Series(val).apply(lambda x: [y.entity for y in x.expected_results.predictions])
             X_test = pd.Series(val).apply(lambda x: x.original)
             y_pred = X_test.apply(model.predict_raw)
@@ -147,8 +149,9 @@ class MaxGenderF1Score(BaseFairness):
         gendered_data = get_gendered_data(data)
 
         samples = []
-
         for key, val in gendered_data.items():
+            if key not in max_scores.keys():
+                continue
             y_true = pd.Series(val).apply(lambda x: [y.entity for y in x.expected_results.predictions])
             X_test = pd.Series(val).apply(lambda x: x.original)
             y_pred = X_test.apply(model.predict_raw)
@@ -171,7 +174,7 @@ class MaxGenderF1Score(BaseFairness):
             sample = Sample(
                 original = "-",
                 category = "fairness",
-                test_type = "min_gender_f1_score",
+                test_type = "max_gender_f1_score",
                 test_case = key,
                 expected_results = MaxScoreOutput(score=max_scores[key]),
                 actual_results = MaxScoreOutput(score=macro_f1_score),


### PR DESCRIPTION
Previous version required all labels to be given in the config, now it can also work with only some labels.
Changes made for bot accuracy and fairness tests.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
