### PR TITLE
Change default data_dir

### DIFF
--- a/demo/utils/conll03.py
+++ b/demo/utils/conll03.py
@@ -60,7 +60,7 @@ class Conll03Dataset(datasets.GeneratorBasedBuilder):
         Conll03Config(
             name="default",
             description=_DESCRIPTION,
-            data_dir="."
+            data_dir="./"
         )
 
     ]


### PR DESCRIPTION
The default python script for loading conll03 into HF datasets is now pointing to an appropriate file path