### PR TITLE
fix: realignment when trailing whitespace in `Transformation`

### DIFF
--- a/nlptest/utils/custom_types/helpers.py
+++ b/nlptest/utils/custom_types/helpers.py
@@ -7,6 +7,11 @@ class Span(BaseModel):
     end: int
     word: str
 
+    @property
+    def ends_with_space(self) -> bool:
+        """"""
+        return self.word.endswith(" ")
+
     def shift_start(self, offset: int) -> None:
         """"""
         self.start -= offset
@@ -26,7 +31,8 @@ class Span(BaseModel):
 
     def __eq__(self, other):
         """"""
-        return self.start == other.start and self.end == other.end
+        return self.start == other.start and \
+               self.end - int(self.ends_with_space) == other.end - int(other.ends_with_space)
 
     def __str__(self):
         """"""

--- a/nlptest/utils/custom_types/sample.py
+++ b/nlptest/utils/custom_types/sample.py
@@ -148,7 +148,9 @@ class NERSample(BaseSample):
                         if transformation.original_span.start == actual_result.span.start and \
                                 transformation.new_span == actual_result.span:
                             # only the end of the span needs to be adjusted
-                            actual_result.span.shift_end(transformation.new_span.end - transformation.original_span.end)
+                            actual_result.span.shift_end(
+                                transformation.new_span.end - transformation.original_span.end
+                            )
                         elif transformation.new_span.start < actual_result.span.start:
                             # the whole span needs to be shifted to the left
                             actual_result.span.shift(
@@ -156,7 +158,8 @@ class NERSample(BaseSample):
                                 (transformation.new_span.end - transformation.original_span.end)
                             )
                         elif transformation.new_span.start >= actual_result.span.start and \
-                                transformation.new_span.end <= actual_result.span.end:
+                                transformation.new_span.end - int(
+                            transformation.new_span.ends_with_space) <= actual_result.span.end:
                             # transformation nested in a span
                             actual_result.span.shift_end(
                                 transformation.new_span.end - transformation.original_span.end

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -329,6 +329,37 @@ class TestNERSample(unittest.TestCase):
         )
         self.assertTrue(sample.is_pass())
 
+    def test_trailing_whitespace_realignment(self):
+        """"""
+        sample = NERSample(
+            original='CRICKET - LARA ENDURES ANOTHER MISERABLE DAY .',
+            test_case='Good Morning CRICKET - LARA ENDURES ANOTHER MISERABLE DAY Reported .',
+            test_type='add_context',
+            expected_results=NEROutput(
+                predictions=[
+                    NERPrediction(entity='DATE', span=Span(start=23, end=44, word='ANOTHER MISERABLE DAY'))
+                ]
+            ),
+            actual_results=NEROutput(
+                predictions=[
+                    NERPrediction(entity='DATE', span=Span(start=36, end=66, word='ANOTHER MISERABLE DAY Reported'))
+                ]
+            ),
+            transformations=[
+                Transformation(
+                    original_span=Span(start=0, end=0, word=''),
+                    new_span=Span(start=0, end=13, word='Good Morning'),
+                    ignore=True
+                ),
+                Transformation(
+                    original_span=Span(start=58, end=58, word=''),
+                    new_span=Span(start=58, end=67, word='Reported '),
+                    ignore=True
+                )
+            ]
+        )
+        self.assertTrue(sample.is_pass())
+
 
 class TestTokenMismatch(unittest.TestCase):
     """"""


### PR DESCRIPTION
This PR aims at fixing #304 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [x] I've used `pydantic` for typing when/where necessary.
- [x] I have linted my code
- [x] I have added tests to cover my changes.
