### PR TITLE
DRAFT: Fix/shouldnt generate after load

### DIFF
--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -132,6 +132,8 @@ class Harness:
         """
         if self._config is None:
             raise RuntimeError("Please call .configure() first.")
+        if self._testcases is not None:
+            raise RuntimeError("Testcases are already generated, please call .run() and .report() next.")
 
         tests = self._config['tests']
         self._testcases = TestFactory.transform(self.data, tests, self.model)


### PR DESCRIPTION
Example output:
```
RuntimeError: Testcases are already generated, please call .run() and .report() next.
```
fixes #241 
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [ ] I have added tests to cover my changes.
