### PR TITLE
Fix: default text classification model issue

### DIFF
--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -27,7 +27,7 @@ class Harness:
         ("ner", "en_core_web_sm", "spacy"): "conll/sample.conll",
         ("ner", "ner.dl", "johnsnowlabs"): "conll/sample.conll",
         ("ner", "ner_dl_bert", "johnsnowlabs"): "conll/sample.conll",
-        ("text-classification", "mrm8488/distilroberta-finetuned-tweets-hate-speech", "huggingface"):
+        ("text-classification", "lvwerra/distilbert-imdb", "huggingface"):
             "tweet/sample.csv",
         ("text-classification", "textcat_imdb", "spacy"): "imdb/sample.csv",
         ("text-classification", "en.sentiment.imdb.glove", "johnsnowlabs"): "imdb/sample.csv"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -159,7 +159,7 @@ class DefaultCodeBlocksTestCase(unittest.TestCase):
 
     def test_text_classification_hf(self):
         """"""
-        h = Harness(task="text-classification", model="mrm8488/distilroberta-finetuned-tweets-hate-speech",
+        h = Harness(task="text-classification", model="lvwerra/distilbert-imdb",
                     hub="huggingface")
         h.generate().run().report()
 


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [ ] I have added tests to cover my changes.
