### PR TITLE
feature/Add support for hf datasets for text classification task

### DIFF
--- a/nlptest/datahandler/datasource.py
+++ b/nlptest/datahandler/datasource.py
@@ -4,14 +4,10 @@ import re
 import jsonlines
 from abc import ABC, abstractmethod
 from typing import Dict, List
-
 from nlptest.utils.custom_types.sample import ToxicitySample
-
 from .format import Formatter
 from ..utils.custom_types import NEROutput, NERPrediction, NERSample, Sample, SequenceClassificationOutput, \
     SequenceClassificationSample, SequenceLabel, QASample, SummarizationSample
-from datasets import load_dataset
-
 
 class _IDataset(ABC):
     """Abstract base class for Dataset.
@@ -574,6 +570,10 @@ class HuggingFaceDataset(_IDataset):
             List[Sample]:
                 Loaded split as a list of Sample objects.
         """
+        try:
+            from datasets import load_dataset
+        except ImportError:
+                raise ModuleNotFoundError("The 'datasets' package is not installed. Please install it using 'pip install datasets'.")
         if subset:
             dataset = load_dataset(self.dataset_name, name=subset, split=split)
         else:

--- a/nlptest/datahandler/datasource.py
+++ b/nlptest/datahandler/datasource.py
@@ -556,7 +556,7 @@ class HuggingFaceDataset(_IDataset):
         """
         self.dataset_name = dataset_name
 
-    def load_data(self, feature_column: str = None, target_column: str = None, split: str = 'test', subset: str = None) -> List[Sample]:
+    def load_data(self, feature_column: str = "text", target_column: str = "label", split: str = 'test', subset: str = None) -> List[Sample]:
         """
         Load the specified split from the dataset library.
 

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -97,7 +97,7 @@ class Harness:
             self.is_default = True
             logging.info("Default dataset '%s' successfully loaded.", (task, model, hub))
 
-        elif data is not None and hub=="huggingface"and task=="text-classification":
+        elif type(data) is dict  and hub=="huggingface"and task=="text-classification":
                 self.data =  HuggingFaceDataset(data['name']).load_data(data['feature_column'],data['target_column'],data['split'],data['subset']) if data is not None else None
                 
         elif data is None and (task, model, hub) not in self.DEFAULTS_DATASET.keys():

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -56,8 +56,8 @@ class Harness:
             hub: Optional[str] = None,
             data: Optional[str] = None,
             config: Optional[Union[str, dict]] = None,
-            feature_column: Optional[str]="text",
-            target_column: Optional[str]= "label",  
+            feature_column: Optional[str]= None,
+            target_column: Optional[str]= None,  
             split:Optional[str]= "test", 
             subset:Optional[str]= None,        
             

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -10,7 +10,7 @@ import yaml
 from pkg_resources import resource_filename
 
 from .augmentation import AugmentRobustness
-from .datahandler.datasource import DataFactory
+from .datahandler.datasource import DataFactory,HuggingFaceDataset
 from .modelhandler import ModelFactory, LANGCHAIN_HUBS
 from .transform import TestFactory
 
@@ -55,7 +55,12 @@ class Harness:
             task: str,
             hub: Optional[str] = None,
             data: Optional[str] = None,
-            config: Optional[Union[str, dict]] = None
+            config: Optional[Union[str, dict]] = None,
+            feature_column: Optional[str]="text",
+            target_column: Optional[str]= "label",  
+            split:Optional[str]= "test", 
+            subset:Optional[str]= None,        
+            
     ):
         """
         Initialize the Harness object.
@@ -98,6 +103,9 @@ class Harness:
             self.is_default = True
             logging.info("Default dataset '%s' successfully loaded.", (task, model, hub))
 
+        elif data is not None and hub=="huggingface"and task=="text-classification":
+                self.data =  HuggingFaceDataset(data).load_data(feature_column,target_column,split,subset) if data is not None else None
+                
         elif data is None and (task, model, hub) not in self.DEFAULTS_DATASET.keys():
             raise ValueError("You haven't specified any value for the parameter 'data' and the configuration you "
                              "passed is not among the default ones. You need to either specify the parameter 'data' "

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -98,7 +98,12 @@ class Harness:
             logging.info("Default dataset '%s' successfully loaded.", (task, model, hub))
 
         elif type(data) is dict  and hub=="huggingface"and task=="text-classification":
-                self.data =  HuggingFaceDataset(data['name']).load_data(data['feature_column'],data['target_column'],data['split'],data['subset']) if data is not None else None
+                self.data = HuggingFaceDataset(data['name']).load_data(
+                    data.get('feature_column', 'text'),
+                    data.get('target_column', 'label'),
+                    data.get('split', 'test'),
+                    data.get('subset', None)
+                ) if data is not None else None
                 
         elif data is None and (task, model, hub) not in self.DEFAULTS_DATASET.keys():
             raise ValueError("You haven't specified any value for the parameter 'data' and the configuration you "

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -98,7 +98,7 @@ class Harness:
             logging.info("Default dataset '%s' successfully loaded.", (task, model, hub))
 
         elif data is not None and hub=="huggingface"and task=="text-classification":
-                self.data =  HuggingFaceDataset(data['data']).load_data(data['feature_column'],data['target_column'],data['split'],data['subset']) if data is not None else None
+                self.data =  HuggingFaceDataset(data['name']).load_data(data['feature_column'],data['target_column'],data['split'],data['subset']) if data is not None else None
                 
         elif data is None and (task, model, hub) not in self.DEFAULTS_DATASET.keys():
             raise ValueError("You haven't specified any value for the parameter 'data' and the configuration you "

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -4,7 +4,6 @@ import pickle
 from collections import defaultdict
 from typing import Dict, List, Optional, Union, Any
 import langchain
-
 import pandas as pd
 import yaml
 from pkg_resources import resource_filename
@@ -54,13 +53,8 @@ class Harness:
             model: Union[str, Any],
             task: str,
             hub: Optional[str] = None,
-            data: Optional[str] = None,
-            config: Optional[Union[str, dict]] = None,
-            feature_column: Optional[str]= None,
-            target_column: Optional[str]= None,  
-            split:Optional[str]= "test", 
-            subset:Optional[str]= None,        
-            
+            data: Optional[Union[str, dict]] = None,
+            config: Optional[Union[str, dict]] = None,            
     ):
         """
         Initialize the Harness object.
@@ -104,7 +98,7 @@ class Harness:
             logging.info("Default dataset '%s' successfully loaded.", (task, model, hub))
 
         elif data is not None and hub=="huggingface"and task=="text-classification":
-                self.data =  HuggingFaceDataset(data).load_data(feature_column,target_column,split,subset) if data is not None else None
+                self.data =  HuggingFaceDataset(data['data']).load_data(data['feature_column'],data['target_column'],data['split'],data['subset']) if data is not None else None
                 
         elif data is None and (task, model, hub) not in self.DEFAULTS_DATASET.keys():
             raise ValueError("You haven't specified any value for the parameter 'data' and the configuration you "

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -133,21 +133,16 @@ class HarnessTestCase(unittest.TestCase):
         """"""
         save_dir = "/tmp/saved_HF_data_text_classification_harness_test"
         tc_harness = Harness(task="text-classification", hub="huggingface",
-                            model="nlptown/flaubert_small_cased_sentiment",
-                            data={
-                                "name":'amazon_reviews_multi',
-                                "subset":"en",
-                                "feature_column":"review_body",
-                                "target_column":'product_category',
-                                "split":"train"
-        })
+                            model="lvwerra/distilbert-imdb",
+                            data={"name":'imdb'}
+                                )
         tc_harness.generate()
         tc_harness.save(save_dir)
 
         loaded_tc_harness = Harness.load(
             save_dir=save_dir,
             task="text-classification",
-            model="nlptown/flaubert_small_cased_sentiment",
+            model="lvwerra/distilbert-imdb",
             hub="huggingface"
         )
         self.assertEqual(tc_harness._config, loaded_tc_harness._config)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -129,6 +129,30 @@ class HarnessTestCase(unittest.TestCase):
         self.assertEqual(tc_harness.data, loaded_tc_harness.data)
         self.assertNotEqual(tc_harness.model, loaded_tc_harness.model)
 
+    def test_load_HF_data_text_classification(self):
+        """"""
+        save_dir = "/tmp/saved_HF_data_text_classification_harness_test"
+        tc_harness = Harness(task="text-classification", hub="huggingface",
+                            model="nlptown/flaubert_small_cased_sentiment",
+                            data={
+                                "name":'amazon_reviews_multi',
+                                "subset":"en",
+                                "feature_column":"review_body",
+                                "target_column":'product_category',
+                                "split":"train"
+        })
+        tc_harness.generate()
+        tc_harness.save(save_dir)
+
+        loaded_tc_harness = Harness.load(
+            save_dir=save_dir,
+            task="text-classification",
+            model="nlptown/flaubert_small_cased_sentiment",
+            hub="huggingface"
+        )
+        self.assertEqual(tc_harness._config, loaded_tc_harness._config)
+        self.assertEqual(tc_harness.data, loaded_tc_harness.data)
+        self.assertNotEqual(tc_harness.model, loaded_tc_harness.model)
 
 class DefaultCodeBlocksTestCase(unittest.TestCase):
     """"""

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -136,6 +136,7 @@ class HarnessTestCase(unittest.TestCase):
                             model="lvwerra/distilbert-imdb",
                             data={"name":'imdb'}
                                 )
+        tc_harness.data=tc_harness.data[:10]
         tc_harness.generate()
         tc_harness.save(save_dir)
 


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I've added Google style docstrings to my code.
- [ ] I've used `pydantic` for typing when/where necessary.
- [ ] I have linted my code
- [x] I have added tests to cover my changes.
-------
- The Harness class for Hugging Face and text classification supports the data parameter, which can also be specified as a dictionary with the following attributes: name, subset, feature_column, target_column, and split.
- By default, the split is set to "test," while the default names for the feature and target columns are "text" and "label" respectively.
- This implementation provides users with the flexibility to load their desired dataset according to their specific requirements.
#### Please find below the code snippet showcasing the utilization of the Harness class for the support of HF Datasets:
```
harness = Harness(task="text-classification", hub="huggingface", model="nlptown/flaubert_small_cased_sentiment",
                    data={
                        "name": "amazon_reviews_multi",
                        "subset": "en",
                        "feature_column": "review_body",
                        "target_column": "product_category",
                        "split": "train"
                    })
```

