### PR TITLE
add new report formats

### DIFF
--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -291,7 +291,7 @@ class Harness:
 
         return self
 
-    def report(self, return_runtime=False, unit='ms', format="dataframe", out=None) -> pd.DataFrame:
+    def report(self, return_runtime=False, unit='ms', format="dataframe", save_dir=None) -> pd.DataFrame:
         """
         Generate a report of the test results.
 
@@ -362,17 +362,17 @@ class Harness:
             elif format=="dict":
                 return self.df_report.to_dict("records")
             elif format=="excel":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                self.df_report.to_excel(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                self.df_report.to_excel(save_dir)
             elif format=="html":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                self.df_report.to_html(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                self.df_report.to_html(save_dir)
             elif format=="markdown":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                self.df_report.to_markdown(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                self.df_report.to_markdown(save_dir)
             elif format=="text" or format=="csv":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                self.df_report.to_csv(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                self.df_report.to_csv(save_dir)
             else:
                 raise ValueError(f"Report in format \"{format}\" is not supported. Please use \"dataframe\", \"excel\", \"html\", \"markdown\", \"text\", \"dict\".")
 
@@ -454,17 +454,17 @@ class Harness:
             elif format=="dict":
                 return styled_df.to_dict("records")
             elif format=="excel":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                styled_df.to_excel(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                styled_df.to_excel(save_dir)
             elif format=="html":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                styled_df.to_html(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                styled_df.to_html(save_dir)
             elif format=="markdown":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                styled_df.to_markdown(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                styled_df.to_markdown(save_dir)
             elif format=="text" or format=="csv":
-                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
-                styled_df.to_csv(out)
+                if save_dir is None: raise ValueError("You need to set \"save_dir\" parameter for this format.")
+                styled_df.to_csv(save_dir)
             else:
                 raise ValueError(f"Report in format \"{format}\" is not supported. Please use \"dataframe\", \"excel\", \"html\", \"markdown\", \"text\", \"dict\".")
 

--- a/nlptest/nlptest.py
+++ b/nlptest/nlptest.py
@@ -291,7 +291,7 @@ class Harness:
 
         return self
 
-    def report(self, return_runtime=False, unit='ms') -> pd.DataFrame:
+    def report(self, return_runtime=False, unit='ms', format="dataframe", out=None) -> pd.DataFrame:
         """
         Generate a report of the test results.
 
@@ -356,7 +356,26 @@ class Harness:
                 self.df_report[f'time_elapsed ({unit})'] = self.df_report['test_type'].apply(
                     lambda x: self._runtime.total_time(unit)[x])
 
-            return self.df_report
+            
+            if format=="dataframe":
+                return self.df_report
+            elif format=="dict":
+                return self.df_report.to_dict("records")
+            elif format=="excel":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                self.df_report.to_excel(out)
+            elif format=="html":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                self.df_report.to_html(out)
+            elif format=="markdown":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                self.df_report.to_markdown(out)
+            elif format=="text" or format=="csv":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                self.df_report.to_csv(out)
+            else:
+                raise ValueError(f"Report in format \"{format}\" is not supported. Please use \"dataframe\", \"excel\", \"html\", \"markdown\", \"text\", \"dict\".")
+
         else:
             df_final_report = pd.DataFrame()
             time_elapsed = {}
@@ -427,8 +446,27 @@ class Harness:
                 df_time_elapsed.set_index('model_name', inplace=True)
                 from IPython.display import display
                 display(df_time_elapsed)
-       
-            return styled_df
+
+
+        
+            if format=="dataframe":
+                return styled_df
+            elif format=="dict":
+                return styled_df.to_dict("records")
+            elif format=="excel":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                styled_df.to_excel(out)
+            elif format=="html":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                styled_df.to_html(out)
+            elif format=="markdown":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                styled_df.to_markdown(out)
+            elif format=="text" or format=="csv":
+                if out is None: raise ValueError("You need to set \"out\" parameter for this format.")
+                styled_df.to_csv(out)
+            else:
+                raise ValueError(f"Report in format \"{format}\" is not supported. Please use \"dataframe\", \"excel\", \"html\", \"markdown\", \"text\", \"dict\".")
 
     def generated_results(self) -> Optional[pd.DataFrame]:
         """


### PR DESCRIPTION
examples:
harness.report(format="dict")
harness.report(format="excel", out="report.xlsx")
harness.report(format="markdown", out="report.md")
harness.report(format="html", out="report.html")
harness.report(format="text", out="report.txt")
